### PR TITLE
Update Slack invite link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/oqtopus-team/quri-parts-oqtopus/graph/badge.svg?token=RCXTMMXOMV)](https://codecov.io/gh/oqtopus-team/quri-parts-oqtopus)
 [![pypi version](https://img.shields.io/pypi/v/quri-parts-oqtopus.svg)](https://pypi.org/project/quri-parts-oqtopus/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08K2QQ30UA)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## Overview
 
@@ -42,6 +42,10 @@ Citation information is also available in the [CITATION](https://github.com/oqto
 You can contact us by creating an issue in this repository or by email:
 
 - [oqtopus-team[at]googlegroups.com](mailto:oqtopus-team[at]googlegroups.com)
+
+or you can join our Slack workspace:
+
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/oqtopus-team/quri-parts-oqtopus/graph/badge.svg?token=RCXTMMXOMV)](https://codecov.io/gh/oqtopus-team/quri-parts-oqtopus)
 [![pypi version](https://img.shields.io/pypi/v/quri-parts-oqtopus.svg)](https://pypi.org/project/quri-parts-oqtopus/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08K2QQ30UA)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## Overview
 
@@ -55,6 +55,10 @@ Citation information is also available in the [CITATION](https://github.com/oqto
 You can contact us by creating an issue in this repository or by email:
 
 - [oqtopus-team[at]googlegroups.com](mailto:oqtopus-team[at]googlegroups.com)
+
+or you can join our Slack workspace:
+
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## License
 


### PR DESCRIPTION
Replace the outdated Slack invite link in the README and index documentation to ensure users can join the workspace easily.