### PR TITLE
Improve quri-parts-oqtopus support for storage-backed job payloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,6 @@ docs = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv.sources]
-oqtopus-client = { path = "../oqtopus-client" }
-
 [tool.ruff]
 preview = true
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
   "certifi",
-  "oqtopus-client>=1.0.2",
+  "oqtopus-client>=1.1.0",
   "quri-parts-circuit>=0.20.3",
   "quri-parts-core>=0.20.3",
   "quri-parts-openqasm>=0.20.3",
@@ -64,6 +64,9 @@ docs = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv.sources]
+oqtopus-client = { path = "../oqtopus-client" }
 
 [tool.ruff]
 preview = true

--- a/src/quri_parts_oqtopus/backend/jobs/sse.py
+++ b/src/quri_parts_oqtopus/backend/jobs/sse.py
@@ -4,6 +4,8 @@ import base64
 from pathlib import Path, PurePath
 
 from oqtopus_client import OqtopusJobSpec
+from oqtopus_client import rest as client_models
+from oqtopus_client.services.job_results import OqtopusJobResult
 from quri_parts.backend import BackendError
 
 from quri_parts_oqtopus.backend.config import OqtopusConfig
@@ -87,11 +89,38 @@ class OqtopusSseBackend(OqtopusJobBackendBase):
                 simulator_info={},
                 mitigation_info={},
             )
-            response_submit_job = self._client.submit_job(spec)
-            response = self._client.get_job(response_submit_job.job_id)
-            job = OqtopusSseJob(job=response, client=self._client)
+            submitted = self._client.submit_job(spec)
+            job = OqtopusSseJob(
+                job=_submitted_sse_job_result(submitted.job_id, spec),
+                client=self._client,
+            )
         except Exception as e:
             msg = "To perform sse on OQTOPUS Cloud is failed."
             raise BackendError(msg) from e
 
         return job
+
+
+def _submitted_sse_job_result(job_id: str, spec: OqtopusJobSpec) -> OqtopusJobResult:
+    program = [spec.program] if isinstance(spec.program, str) else list(spec.program)
+
+    return OqtopusJobResult(
+        job_id=job_id,
+        job_type=client_models.JobsJobType.SSE,
+        status=client_models.JobsJobStatus.SUBMITTED,
+        name=spec.name or "",
+        description=spec.description,
+        device_id=spec.device_id,
+        shots=spec.shots,
+        job_info={
+            "input": {
+                "program": program,
+                "operator": [],
+                "sse_program": None,
+            },
+            "message": None,
+        },
+        transpiler_info=spec.transpiler_info,
+        simulator_info=spec.simulator_info,
+        mitigation_info=spec.mitigation_info,
+    )

--- a/src/quri_parts_oqtopus/models/jobs/sse.py
+++ b/src/quri_parts_oqtopus/models/jobs/sse.py
@@ -48,16 +48,14 @@ class OqtopusSseJob(OqtopusJobBase):
         Returns:
             OqtopusSamplingResult: the result of the sampling job.
 
-        Raises:
-            BackendError: If job cannot be found or if an authentication error occurred
-                or timeout occurs, etc.
-
         """
-        try:
-            sampling_job = OqtopusSamplingJob(job=self._job, client=self._client)
-        except BackendError as e:
-            msg = f"Failed to create OqtopusSamplingJob: {e}"
-            raise BackendError(msg) from e
+        if self.status not in JOB_FINAL_STATUS:
+            self._job = self._client.wait(
+                self.job_id,
+                interval=wait,
+                timeout=timeout,
+            )
+        sampling_job = OqtopusSamplingJob(job=self._job, client=self._client)
 
         return sampling_job.result(timeout=timeout, wait=wait)
 

--- a/tests/quri_parts_oqtopus/backend/test_sse.py
+++ b/tests/quri_parts_oqtopus/backend/test_sse.py
@@ -194,7 +194,7 @@ class TestOqtopusSseBackend:  # noqa: PLR0904
         # Assert
         assert ret_job.job_id == job.job_id
         spec = mock_submit_job.call_args.args[0]
-        assert spec.program[0] == base64.b64encode(read_data).decode("utf-8")
+        assert spec.program == read_data.decode("utf-8")
         assert spec.job_type.value == "sse"
 
     def test_run_sse_invalid_arg(self) -> None:
@@ -275,7 +275,7 @@ class TestOqtopusSseBackend:  # noqa: PLR0904
 
         # Assert
         spec = mock_submit_job.call_args.args[0]
-        assert spec.program[0] == base64.b64encode(read_data).decode("utf-8")
+        assert spec.program == read_data.decode("utf-8")
         assert spec.job_type.value == "sse"
 
     def test_download_log(self, mocker: MockerFixture) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1760,8 +1760,8 @@ wheels = [
 
 [[package]]
 name = "oqtopus-client"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+version = "1.1.0"
+source = { directory = "../oqtopus-client" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -1771,10 +1771,30 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/94/b827865abc5bc48a81b42ea987a3869b573b0124342ea7fad82e2ad227f8/oqtopus_client-1.0.2.tar.gz", hash = "sha256:9bf05dfaca2f21bf84a022dcbe8d0ae6f6367e074725ede64aaaa0117d69e65e", size = 59998, upload-time = "2026-05-14T02:06:37.971Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/be/a6f4fe1bd34c4da069233cc191a12afd40a56c5e39f95a9b438476eee5e8/oqtopus_client-1.0.2-py3-none-any.whl", hash = "sha256:80f974a854a7d79a115ac7d477bf69f74073b928861e4cfdcb656e0a4bca3dee", size = 125142, upload-time = "2026-05-14T02:06:36.252Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.0.0" },
+    { name = "aiohttp-retry", specifier = ">=2.8.3" },
+    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.0" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
+    { name = "mkdocs-gen-files", marker = "extra == 'dev'", specifier = ">=0.5.0" },
+    { name = "mkdocs-literate-nav", marker = "extra == 'dev'", specifier = ">=0.6.1" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.0" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
+    { name = "pydantic", specifier = ">=2.7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "python-dateutil", specifier = ">=2.5.3" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.9.0.20250516" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20241230" },
+    { name = "typing-extensions", specifier = ">=4.7.1" },
+    { name = "urllib3", specifier = ">=1.25.3,<2.1.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "packaging"
@@ -2593,7 +2613,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "certifi" },
-    { name = "oqtopus-client", specifier = ">=1.0.2" },
+    { name = "oqtopus-client", directory = "../oqtopus-client" },
     { name = "quri-parts-circuit", specifier = ">=0.20.3" },
     { name = "quri-parts-core", specifier = ">=0.20.3" },
     { name = "quri-parts-openqasm", specifier = ">=0.20.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ wheels = [
 [[package]]
 name = "oqtopus-client"
 version = "1.1.0"
-source = { directory = "../oqtopus-client" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
@@ -1771,30 +1771,10 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.0.0" },
-    { name = "aiohttp-retry", specifier = ">=2.8.3" },
-    { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.0" },
-    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
-    { name = "mkdocs-gen-files", marker = "extra == 'dev'", specifier = ">=0.5.0" },
-    { name = "mkdocs-literate-nav", marker = "extra == 'dev'", specifier = ">=0.6.1" },
-    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.0" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.28.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
-    { name = "pydantic", specifier = ">=2.7.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "python-dateutil", specifier = ">=2.5.3" },
-    { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
-    { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.9.0.20250516" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20241230" },
-    { name = "typing-extensions", specifier = ">=4.7.1" },
-    { name = "urllib3", specifier = ">=1.25.3,<2.1.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/9c/6c/c769a611e75c245e8e91e4fae37d648ae0bb1fff04051c15836ed46a85e6/oqtopus_client-1.1.0.tar.gz", hash = "sha256:006de0752f2289d7b1aef2d32437f91d86f62b7db614189f5d5816667db3a6f1", size = 62701, upload-time = "2026-05-22T07:32:18.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/15/acc228a934e7960b43e1b01c447e3b017f7a85a8b5f6f957ba20636de8ef/oqtopus_client-1.1.0-py3-none-any.whl", hash = "sha256:47dc53ed0f60110e8261e417356837a7138189b27e5768123928ba47bfb12795", size = 128244, upload-time = "2026-05-22T07:32:16.947Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "packaging"
@@ -2613,7 +2593,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "certifi" },
-    { name = "oqtopus-client", directory = "../oqtopus-client" },
+    { name = "oqtopus-client", specifier = ">=1.1.0" },
     { name = "quri-parts-circuit", specifier = ">=0.20.3" },
     { name = "quri-parts-core", specifier = ">=0.20.3" },
     { name = "quri-parts-openqasm", specifier = ">=0.20.3" },


### PR DESCRIPTION
## Summary

Fixes #31

This PR adds support for storage-backed job payloads in quri-parts-oqtopus so that large job data managed via S3 can be handled through the current OQTOPUS Cloud API.

Main changes:
- migrate job and device access to oqtopus-client
- update sampling / estimation / sse job handling for the current API
- support storage-backed SSE log retrieval
- remove the legacy generated REST client
- update related tests and documentation

## Motivation

As discussed in #31, quri-parts-oqtopus needs to support job data managed outside the inline API response.
This change aligns quri-parts-oqtopus with the current storage-backed job_info flow used by OQTOPUS Cloud.

## Validation

- validated migrated jobs through both oqtopus-client and quri-parts-oqtopus
- confirmed sampling / estimation / multi_manual / sse job reads
- confirmed SSE result handling and SSE log retrieval
- updated related tests
