### PR TITLE
chore: bump oqtopus-client to 1.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
   "certifi",
-  "oqtopus-client>=1.1.2",
+  "oqtopus-client>=1.1.3",
   "quri-parts-circuit>=0.20.3",
   "quri-parts-core>=0.20.3",
   "quri-parts-openqasm>=0.20.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "oqtopus-client"
-version = "1.1.2"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1771,9 +1771,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/be/85b39ab759e66ce2df1c1de641be9e3491de8065c824ed6481cc406015ba/oqtopus_client-1.1.2.tar.gz", hash = "sha256:65f5b4ccc0adde873a2d040ecececc73fc7b93ff5b0b15595a56b07734001961", size = 63355, upload-time = "2026-05-27T01:36:53.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/8b/1369b30aa938868104cfc583418b340ee58e26e5734295e73a4be0d75ebe/oqtopus_client-1.1.3.tar.gz", hash = "sha256:93cd7543ac226351db7490cb1399d5924ae9be08350a89815c8913837429bb27", size = 63357, upload-time = "2026-05-27T06:11:59.862Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/b3/ba79235c10bfa103b81783a07711f362415880e8a076c7b32388ee202c92/oqtopus_client-1.1.2-py3-none-any.whl", hash = "sha256:bf8be8c4ea12a8f48897fd97d1ef9b67af4f0cb6098c090f9d1a11794b475e08", size = 128841, upload-time = "2026-05-27T01:36:52.353Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e6/a9d6179f55625ea6bf34b222b5eb4dfc2a7fa53c2a349cfcc26df8fdad2d/oqtopus_client-1.1.3-py3-none-any.whl", hash = "sha256:e3699704ff3d674fbed5bc74cd49918f45fd9f4b9557141529e64c3be166bc02", size = 128854, upload-time = "2026-05-27T06:11:58.558Z" },
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "certifi" },
-    { name = "oqtopus-client", specifier = ">=1.1.2" },
+    { name = "oqtopus-client", specifier = ">=1.1.3" },
     { name = "quri-parts-circuit", specifier = ">=0.20.3" },
     { name = "quri-parts-core", specifier = ">=0.20.3" },
     { name = "quri-parts-openqasm", specifier = ">=0.20.3" },


### PR DESCRIPTION
## Summary
- bump quri-parts-oqtopus dependency to oqtopus-client 1.1.3
- align with the latest SSE log download fix in oqtopus-client

## Background
oqtopus-client 1.1.3 includes a fix for SSE log download behavior.
Previously, `get_sselog()` could return extracted text while keeping a `.zip` filename, which caused downstream consumers to save an invalid ZIP file.
quri-parts-oqtopus downloads SSE logs through oqtopus-client, so it should depend on the fixed version to ensure the downloaded `sse_log` archive is valid and can be unzipped correctly.

## Impact
- SSE log download via quri-parts-oqtopus uses the fixed oqtopus-client behavior
- no intended API change in quri-parts-oqtopus itself
- this is a dependency alignment update for the 1.1.3 bugfix release
