### PR TITLE
chore: require oqtopus-client 1.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10,<3.14"
 dependencies = [
   "certifi",
-  "oqtopus-client>=1.1.5",
+  "oqtopus-client>=1.1.6",
   "quri-parts-circuit>=0.20.3",
   "quri-parts-core>=0.20.3",
   "quri-parts-openqasm>=0.20.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "oqtopus-client"
-version = "1.1.5"
+version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1771,9 +1771,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/8a/96268ec209fa330d617a4b969c14bfcb81df5e4d8f2968981d05485900f4/oqtopus_client-1.1.5.tar.gz", hash = "sha256:66c0a5ffb0e9a5d9b7d33a4b55ff7d7123c65a9f88ed8b6fe9e7c92acc8d4ce7", size = 63763, upload-time = "2026-06-11T00:37:39.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/c4/f6f049ab6a37964ce841783a3dff7eb49049754da63f424839fa68126029/oqtopus_client-1.1.6.tar.gz", hash = "sha256:402fd17092eba51a07a5b80dd6276f2974c233928f25e5d834606a7259c28be8", size = 63724, upload-time = "2026-06-17T06:41:46.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/f7/f24d6e1076c39693707968178f0465fdc752721c8d5d86a17dd5e017ad16/oqtopus_client-1.1.5-py3-none-any.whl", hash = "sha256:3db98b3ed0db78b5cd7ba3beb2e0ab341336e988a17d9642c3bf969ce0188844", size = 129289, upload-time = "2026-06-11T00:37:38.348Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/24/6078264494c2509ac699cc32ee6e52dbaa1c17f0b16108b7b023200c0c07/oqtopus_client-1.1.6-py3-none-any.whl", hash = "sha256:d63aca8229105407a68308cd0fe8d46f29f8a740fb0fb14c87d0b664bd627cd2", size = 129269, upload-time = "2026-06-17T06:41:44.923Z" },
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "certifi" },
-    { name = "oqtopus-client", specifier = ">=1.1.5" },
+    { name = "oqtopus-client", specifier = ">=1.1.6" },
     { name = "quri-parts-circuit", specifier = ">=0.20.3" },
     { name = "quri-parts-core", specifier = ">=0.20.3" },
     { name = "quri-parts-openqasm", specifier = ">=0.20.3" },


### PR DESCRIPTION
## Summary

Raise the minimum required oqtopus-client version to 1.1.6.

## Why

quri-parts-oqtopus should not allow oqtopus-client 1.1.5 or lower when the bug fix in 1.1.6 is required for supported usage.

## Changes

- update the dependency lower bound from oqtopus-client>=1.1.5 to >=1.1.6
- refresh uv.lock to resolve oqtopus-client 1.1.6

## Validation

- uv lock
- uv sync --group test
- uv run pytest -q
